### PR TITLE
Move Filament validation to config, so it is configurable per project…

### DIFF
--- a/config/filament-redirects.php
+++ b/config/filament-redirects.php
@@ -3,4 +3,5 @@
 return [
     'route-wildcard' => '*',
     'default-status' => 302,
+    'input-validation' => ['required'],
 ];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,3 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
-

--- a/src/Filament/RedirectResource.php
+++ b/src/Filament/RedirectResource.php
@@ -24,11 +24,11 @@ class RedirectResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('from')
-                    ->rules(['url', 'required'])
+                    ->rules(config('filament-redirects.input-validation', ['required']))
                     ->required(),
 
                 Forms\Components\TextInput::make('to')
-                    ->rules(['url', 'required'])
+                    ->rules(config('filament-redirects.input-validation', ['required']))
                     ->required(),
 
                 Forms\Components\Select::make('status')

--- a/tests/Feature/Filament/RedirectResource/Pages/ManageRedirectsTest.php
+++ b/tests/Feature/Filament/RedirectResource/Pages/ManageRedirectsTest.php
@@ -102,6 +102,10 @@ it('can create a redirect', function () {
 });
 
 it('can create a redirect with validation errors for invalid URLs', function () {
+    config([
+        'filament-redirects.input-validation' => ['url', 'required'],
+    ]);
+
     livewire(ManageRedirects::class)
         ->assertActionExists('create')
         ->callAction('create', [
@@ -124,6 +128,23 @@ it('can create a redirect with different protocols', function () {
     $this->assertDatabaseHas(Redirect::class, [
         'from' => 'http://example.com/old',
         'to' => 'https://example.com/new',
+        'status' => 301,
+    ]);
+});
+
+it('can create a redirect with relative url', function () {
+    livewire(ManageRedirects::class)
+        ->assertActionExists('create')
+        ->callAction('create', [
+            'from' => '/old',
+            'to' => '/new',
+            'status' => 301,
+        ])
+        ->assertHasNoActionErrors();
+
+    $this->assertDatabaseHas(Redirect::class, [
+        'from' => '/old',
+        'to' => '/new',
         'status' => 301,
     ]);
 });


### PR DESCRIPTION
…, because multi-domain projects need absolute urls and single-domain urls can use relative urls.