### PR TITLE
Hotfix/fil001 164  rtrim trailing slash

### DIFF
--- a/src/Models/Redirect.php
+++ b/src/Models/Redirect.php
@@ -48,17 +48,13 @@ class Redirect extends Model implements Sortable
 
     public function getCleanFromAttribute()
     {
-        return Str::ascii(
-            urldecode(
-                trim(
-                    (
-                        Str::startsWith($this->from, '/') || Str::startsWith($this->from, 'http')
-                            ? ''
-                            : '/'
-                    ) . $this->from
-                )
-            )
-        );
+        $dontAddSlash = Str::startsWith($this->from, '/') || Str::startsWith($this->from, 'http');
+
+        return (string) Str::of(urldecode($this->from))
+            ->start($dontAddSlash ? '' : '/')
+            ->ascii()
+            ->trim()
+            ->rtrim('/');
     }
 
     /**

--- a/tests/Feature/Imports/RedirectsImportTest.php
+++ b/tests/Feature/Imports/RedirectsImportTest.php
@@ -2,7 +2,7 @@
 
 use Maatwebsite\Excel\Facades\Excel;
 
-//it('can import redirects', function () {
+// it('can import redirects', function () {
 //    Excel::fake();
 //
 //    $this->actingAs($this->givenUser())
@@ -19,4 +19,4 @@ use Maatwebsite\Excel\Facades\Excel;
 //        return true;
 //    });
 //
-//});
+// });


### PR DESCRIPTION
URL mapping in [BRU001](https://bru001.master.agency.wotz.be/admin/redirects) was not working because of the trailing slashes at the end of the “from”
Fixed by rtrimming the from before use