### PR TITLE
BRU001-105 Ignore trailing slash at the end

### DIFF
--- a/src/Http/Middleware/Redirects.php
+++ b/src/Http/Middleware/Redirects.php
@@ -41,10 +41,13 @@ class Redirects
             'fullWithoutProtocolNoQuery' => Str::beforeLast($uriWithoutProtocol, '?'),
             'path' => $requestUri,
             'pathNoQuery' => Str::beforeLast($requestUri, '?'),
+            'pathWithoutTrailingSlash' => Str::replaceEnd('/', '', $requestUri),
+            'pathWithTrailingSlash' => Str::finish($requestUri, '/'),
         ];
 
-        $activeRedirect = $urlMaps->first(function ($redirect) use ($current) {
+        $activeRedirect = $urlMaps->first(function (Redirect $redirect) use ($current) {
             $from = $redirect->clean_from;
+
             $fromWithoutProtocol = preg_replace('~^https?://~', '', $from);
 
             $hasWildcard = Str::contains($from, config('filament-redirects.route-wildcard', '*'));

--- a/tests/Feature/Http/Middleware/RedirectsTest.php
+++ b/tests/Feature/Http/Middleware/RedirectsTest.php
@@ -129,3 +129,35 @@ it('will redirect with a wildcard', function () {
     $this->assertEquals($response2->getStatusCode(), 302);
     $this->assertEquals($response2->getTargetUrl(), 'http://localhost/to');
 });
+
+it('will redirect if redirect has a trailing slash', function () {
+    Redirect::factory()->create([
+        'sort_order' => 1,
+        'from' => '/from/',
+        'to' => '/to',
+        'status' => 302,
+        'pass_query_string' => true,
+        'online' => true,
+    ]);
+
+    $response = createResponse('/from');
+
+    $this->assertEquals($response->getStatusCode(), 302);
+    $this->assertEquals($response->getTargetUrl(), 'http://localhost/to');
+});
+
+it('will redirect if redirect has no trailing slash', function () {
+    Redirect::factory()->create([
+        'sort_order' => 1,
+        'from' => '/from/',
+        'to' => '/to',
+        'status' => 302,
+        'pass_query_string' => true,
+        'online' => true,
+    ]);
+
+    $response = createResponse('/from/');
+
+    $this->assertEquals($response->getStatusCode(), 302);
+    $this->assertEquals($response->getTargetUrl(), 'http://localhost/to');
+});


### PR DESCRIPTION
So we redirect properly if url has or has no trailing slash